### PR TITLE
Separator configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: node:8.2.1
+      - image: node:15.8
     steps:
       - checkout
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "url": "https://github.com/Shudrum/sass-easy-bem.git"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^6.2.0",
-    "node-sass": "^4.12.0"
+    "chai": "^4.3.0",
+    "mocha": "^8.3.0",
+    "node-sass": "^5.0.0"
   },
   "style": "easy-bem.scss",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "sass-easy-bem",
   "description": "BEM made easy for Sass",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "keywords": [
     "css",

--- a/sass-easy-bem.scss
+++ b/sass-easy-bem.scss
@@ -7,6 +7,9 @@
 
 // Utility functions
 
+$element-separator: '__' !default;
+$modifier-separator: '--' !default;
+
 @function get-parent-selector($selector) {
   $parent: null;
   @while str-index('#{$selector}', ' ') {
@@ -30,27 +33,24 @@
 }
 
 @function get-block($selector) {
-  $have-element: str-index('#{&}', '__');
-  $have-modifier: str-index('#{&}', '--');
+  $have-element: str-index('#{&}', $element-separator);
+  $have-modifier: str-index('#{&}', $modifier-separator);
 
   @if ($have-element) {
-    @return str-slice('#{$selector}', 0, str-index('#{&}', '__') - 1);
+    @return str-slice('#{$selector}', 0, str-index('#{&}', $element-separator) - 1);
   }
   @if ($have-modifier) {
-    @return str-slice('#{$selector}', 0, str-index('#{&}', '--') - 1);
+    @return str-slice('#{$selector}', 0, str-index('#{&}', $modifier-separator) - 1);
   }
   @return $selector;
 }
 
 @function get-element($selector) {
-  $have-modifier: str-index('#{$selector}', '--');
-  @if ($have-modifier) {
-    $selector: str-slice('#{$selector}', 0, str-index('#{$selector}', '--') - 1);
-    @while (str-index(str-slice('#{$selector}', 2), '.')) {
-      $selector: str-slice('#{$selector}', str-index(str-slice('#{$selector}', 2), '.') + 1);
-    }
+  $selector: str-slice('#{$selector}', 2);
+  @while (str-index($selector, '.')) {
+    $selector: str-slice('#{$selector}', 0, str-index($selector, '.') - 1);
   }
-  @return $selector;
+  @return '.#{$selector}';
 };
 
 // BEM
@@ -64,36 +64,36 @@
 }
 
 @mixin element($element) {
-  $is-modifier: str-index('#{&}', '--');
+  $is-modifier: str-index('#{&}', $modifier-separator);
   $block: get-block(&);
 
   @if not $is-modifier {
     @at-root {
-      #{$block}__#{$element} {
+      #{$block}#{$element-separator}#{$element} {
         @content;
       }
     }
   }
 
   @if $is-modifier {
-    $is-element: str-index('#{&}', '__');
+    $is-element: str-index('#{&}', $element-separator);
 
     @if $is-element {
-      $block: str-slice('#{&}', 0, str-index('#{&}', '__') - 1);
+      $block: str-slice('#{&}', 0, str-index('#{&}', $element-separator) - 1);
 
       @at-root {
-        & #{$block}__#{$element} {
+        & #{$block}#{$element-separator}#{$element} {
           @content;
         }
       }
     }
 
     @if not $is-element {
-      $block: str-slice('#{&}', 0, str-index('#{&}', '--') - 1);
+      $block: str-slice('#{&}', 0, str-index('#{&}', $modifier-separator) - 1);
       $block: str-slice($block, 1, str-index(str-slice($block, 2, -1), '.'));
 
       @at-root {
-        & #{$block}__#{$element} {
+        & #{$block}#{$element-separator}#{$element} {
           @content;
         }
       }
@@ -108,12 +108,12 @@
 
   @at-root {
     @if ($parent-selector) {
-      #{$parent-selector} #{$last-selector}#{$element}--#{$modifier} {
+      #{$parent-selector} #{$last-selector}#{$element}#{$modifier-separator}#{$modifier} {
         @content;
       }
     }
     @else {
-      #{$last-selector}#{$element}--#{$modifier} {
+      #{$last-selector}#{$element}#{$modifier-separator}#{$modifier} {
         @content;
       }
     }

--- a/test/differentSeparators.test.js
+++ b/test/differentSeparators.test.js
@@ -1,0 +1,185 @@
+const testAll = require('./testAll');
+
+describe('Modifier', () => {
+  testAll([{
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include element('element') {
+          @include modifier('modifier') {
+            color: blue;
+          }
+        }
+      }
+    `,
+    css: `
+      .block__element.block__element_modifier { color: blue; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include modifier('modifier') {
+          color: red;
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include modifier('modifier') {
+          color: red;
+          @include element('element') {
+            color: blue;
+          }
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+      .block.block_modifier .block__element { color: blue; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include modifier('modifier') {
+          color: red;
+          @include element('element') {
+            color: blue;
+            @include modifier('second-modifier') {
+              color: green;
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+      .block.block_modifier .block__element { color: blue; }
+      .block.block_modifier .block__element.block__element_second-modifier { color: green; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include modifier('modifier') {
+          color: red;
+          @include element('element') {
+            color: blue;
+            @include modifier('second-modifier') {
+              color: green;
+              @include modifier('third-modifier') {
+                color: yellow;
+              }
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+      .block.block_modifier .block__element { color: blue; }
+      .block.block_modifier .block__element.block__element_second-modifier { color: green; }
+      .block.block_modifier .block__element.block__element_second-modifier.block__element_third-modifier { color: yellow; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include b('block') {
+        @include m('modifier') {
+          color: red;
+          @include e('element') {
+            color: blue;
+            @include m('second-modifier') {
+              color: green;
+              @include m('third-modifier') {
+                color: yellow;
+              }
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+      .block.block_modifier .block__element { color: blue; }
+      .block.block_modifier .block__element.block__element_second-modifier { color: green; }
+      .block.block_modifier .block__element.block__element_second-modifier.block__element_third-modifier { color: yellow; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include modifier('modifier') {
+          color: red;
+          @include element('element') {
+            color: blue;
+            @include modifier('second-modifier') {
+              color: green;
+              @include modifier('third-modifier') {
+                color: yellow;
+                @include modifier('never-ending-modifier') {
+                  color: purple;
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block.block_modifier { color: red; }
+      .block.block_modifier .block__element { color: blue; }
+      .block.block_modifier .block__element.block__element_second-modifier { color: green; }
+      .block.block_modifier .block__element.block__element_second-modifier.block__element_third-modifier { color: yellow; }
+      .block.block_modifier .block__element.block__element_second-modifier.block__element_third-modifier.block__element_never-ending-modifier { color: purple; }
+    `,
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include element('element') {
+          @include modifier('modifier') {
+            @include element('second-element') {
+              @include modifier('second-modifier') {
+                @include modifier('third-modifier') {
+                  color: red;
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block__element.block__element_modifier .block__second-element.block__second-element_second-modifier.block__second-element_third-modifier { color: red; }
+    `
+  }, {
+    scss: `
+      $modifier-separator: '_';
+      @include block('block') {
+        @include element('element') {
+          @include modifier('modifier') {
+            @include element('second-element') {
+              color: blue;
+              @include modifier('second-modifier') {
+                @include modifier('third-modifier') {
+                  color: red;
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    css: `
+      .block__element.block__element_modifier .block__second-element { color: blue; }
+      .block__element.block__element_modifier .block__second-element.block__second-element_second-modifier.block__second-element_third-modifier { color: red; }
+    `
+  }]);
+});


### PR DESCRIPTION
Allow users to change the separators configuration to fit their usage.

For example, some people may need to do: `block__element_modifier`.